### PR TITLE
Potential fix for code scanning alert no. 73: Database query built from user-controlled sources

### DIFF
--- a/backend/src/routes/accessRequests.js
+++ b/backend/src/routes/accessRequests.js
@@ -81,7 +81,7 @@ router.get('/v1/access-requests', authGuard, requireRole('admin'), async (req, r
     // Support pagination for large orgs. Query params: page, limit
     const { status, limit = 50, page = 1 } = req.query;
     const q = {};
-    if (status) q.status = status;
+    if (typeof status === 'string' && status.length > 0) q.status = { $eq: status };
     const pageNum = Math.max(1, Number(page) || 1);
     const perPage = Math.max(1, Math.min(500, Number(limit) || 50));
     const skip = (pageNum - 1) * perPage;


### PR DESCRIPTION
Potential fix for [https://github.com/GeoAziz/EthAI-Guard/security/code-scanning/73](https://github.com/GeoAziz/EthAI-Guard/security/code-scanning/73)

To safely embed untrusted user input into a MongoDB query, ensure that the input cannot be interpreted as a query object. The recommended fix is to either:  
(1) Use the `$eq` operator for the `status` field (i.e., `q.status = { $eq: status }`), which ensures that only documents matching the exact string value are selected, and prevents operator injection;  
or  
(2) Validate that `status` is a string and does not itself contain object properties before inclusion in the query (e.g., `typeof status === "string"`).

The best way to fix this, without changing existing functionality, is to (a) check that `status` is a non-empty string, and (b) assign `q.status = { $eq: status }` (to force an equality match), else ignore status if invalid.  
These changes affect the block from line 82–84 in backend/src/routes/accessRequests.js.  
No new imports or definitions are required, only a minor code edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
