### PR TITLE
Potential fix for code scanning alert no. 69: Reflected cross-site scripting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,8 @@
     "xss-clean": "^0.1.4",
     "uuid": "^9.0.0",
     "winston": "^3.18.3",
-    "winston-mongodb": "^7.0.1"
+    "winston-mongodb": "^7.0.1",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "eslint": "^8.50.0",

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -11,6 +11,7 @@ const hpp = optRequire('hpp');
 const compression = optRequire('compression');
 const xssClean = optRequire('xss-clean');
 const mongoose = require('mongoose');
+const escape = require('escape-html');
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 const argon2 = require('argon2');
@@ -1543,7 +1544,9 @@ app.get('/report/:id/export', authMiddleware, async (req, res) => {
 		}
 
 		// Fallback: serve printable HTML
-		const html = `<!doctype html><html><head><meta charset="utf-8"><title>Report ${req.params.id}</title><style>body{font-family:system-ui,Arial,Helvetica,sans-serif;padding:20px}</style></head><body><h1>Report ${req.params.id}</h1><pre>${JSON.stringify(rpt, null, 2)}</pre></body></html>`;
+		const safeId = escape(req.params.id);
+		const safeReport = escape(JSON.stringify(rpt, null, 2));
+		const html = `<!doctype html><html><head><meta charset="utf-8"><title>Report ${safeId}</title><style>body{font-family:system-ui,Arial,Helvetica,sans-serif;padding:20px}</style></head><body><h1>Report ${safeId}</h1><pre>${safeReport}</pre></body></html>`;
 		res.set('Content-Type', 'text/html');
 		return res.send(html);
 	} catch (e) {


### PR DESCRIPTION
Potential fix for [https://github.com/GeoAziz/EthAI-Guard/security/code-scanning/69](https://github.com/GeoAziz/EthAI-Guard/security/code-scanning/69)

To fix the vulnerability, all user-provided data that is output to the HTML response must be safely escaped before embedding in the HTML. The simplest, most reliable way is to use a well-established escaping library such as `escape-html` to sanitize `req.params.id` and all property values from the `rpt` object before outputting them to the response. For the `JSON.stringify(rpt, ...)` output, since data can contain any string, you should escape the result or each field before embedding. For safety and simplicity, escape the entire `JSON.stringify(rpt, null, 2)` result before injection into `<pre>`. Additionally, `req.params.id` should be escaped anywhere it is reflected in the HTML (both `<title>` and `<h1>`). Thus:

- Add `escape-html` as a dependency.
- Require it at the top of the file (or after optRequire block to match usage style).
- In the `/report/:id/export` handler, escape `req.params.id` everywhere it appears in HTML.
- Escape the serialized report JSON before embedding it in the HTML response.

All edits are confined to backend/src/server.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
