### PR TITLE
fix(frontend): remove webpack fallback overrides that break Next client runtime

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -57,27 +57,6 @@ const nextConfig: NextConfig = {
       },
     ];
   },
-  webpack(config, { isServer }) {
-    if (!isServer) {
-      // Prevent Node.js-only built-in modules from being bundled into the
-      // client bundle. `server-only` guards db-client / firebase-admin at
-      // build time, but explicit browser fallbacks stop webpack from trying
-      // to polyfill heavy native modules if they ever appear in the dep tree.
-      config.resolve = config.resolve ?? {};
-      config.resolve.fallback = {
-        ...config.resolve.fallback,
-        fs: false,
-        net: false,
-        tls: false,
-        dns: false,
-        crypto: false,
-        path: false,
-        stream: false,
-        os: false,
-      };
-    }
-    return config;
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
### Motivation
- The project included a custom client-side `webpack` `resolve.fallback` override in `frontend/next.config.ts` that forced Node builtins to false for the browser bundle and could cause required runtime modules to become undefined, producing client-side errors such as `options.factory` / `__webpack_require__` failures.

### Description
- Removed the client `webpack` `resolve.fallback` override block from `frontend/next.config.ts` so Next.js uses its default browser bundling/module resolution while keeping the rest of the Next config (headers, images, TypeScript/eslint options) intact.

### Testing
- Ran `npm run lint` in `frontend` (this failed due to many pre-existing lint errors unrelated to this change); started the dev server with `npm run dev` (succeeded) and verified the app responded with `200 OK` using `curl -i -s http://localhost:3000/login`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6d0e081ac832fa207bd549c27b03c)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/GeoAziz/EthAI-Guard/24?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->