### PR TITLE
Use env-aware Cache-Control for _next/static and remove webpack node fallbacks

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -34,6 +34,11 @@ const nextConfig: NextConfig = {
     ],
   },
   async headers() {
+    const staticCacheControl =
+      process.env.NODE_ENV === 'production'
+        ? 'public, max-age=31536000, immutable'
+        : 'no-store, max-age=0';
+
     return [
       {
         source: '/sw.js',
@@ -45,7 +50,7 @@ const nextConfig: NextConfig = {
       {
         source: '/_next/static/(.*)',
         headers: [
-          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+          { key: 'Cache-Control', value: staticCacheControl },
         ],
       },
       {
@@ -56,27 +61,6 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
-  },
-  webpack(config, { isServer }) {
-    if (!isServer) {
-      // Prevent Node.js-only built-in modules from being bundled into the
-      // client bundle. `server-only` guards db-client / firebase-admin at
-      // build time, but explicit browser fallbacks stop webpack from trying
-      // to polyfill heavy native modules if they ever appear in the dep tree.
-      config.resolve = config.resolve ?? {};
-      config.resolve.fallback = {
-        ...config.resolve.fallback,
-        fs: false,
-        net: false,
-        tls: false,
-        dns: false,
-        crypto: false,
-        path: false,
-        stream: false,
-        os: false,
-      };
-    }
-    return config;
   },
 };
 


### PR DESCRIPTION
### Motivation

- Ensure static assets under `/_next/static/(.*)` receive aggressive immutable caching in production but avoid that during development by making the header env-aware via `process.env.NODE_ENV`.
- Rely on Next.js/webpack defaults instead of custom browser fallbacks to avoid maintaining manual polyfill/falsey mappings for Node built-ins.

### Description

- Introduce a `staticCacheControl` variable that uses `public, max-age=31536000, immutable` in production and `no-store, max-age=0` otherwise, and apply it to the `/_next/static/(.*)` `Cache-Control` header.
- Leave `sw.js` and `manifest.json` headers unchanged except for using the new header logic for static assets when appropriate.
- Remove the custom `webpack` function that added explicit `resolve.fallback` entries for Node built-ins such as `fs`, `net`, `tls`, `dns`, `crypto`, `path`, `stream`, and `os`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6d0e081ac832fa207bd549c27b03c)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/GeoAziz/EthAI-Guard/25?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->